### PR TITLE
Testing at Travis-CI is now available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ sudo: false
 
 language: perl
 
+# normally cpanm is called for perl, but we do not need it so skip the installation of dependencies
+install: true
+
 script:
   - cd t
   - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+
+language: perl
+
+script:
+  - cd t
+  - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+  
 sudo: false
 
 language: perl

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ os:
   - linux
   - osx
   
+# due to we are sure about the MacOSX version, I tollerate build failures under osx
+matrix:
+  allow_failures:
+    - os: osx
+  
 sudo: false
 
 language: perl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install: true
 
 script:
   - cd t
-  - ./test.sh
+  - prove ./test.sh


### PR DESCRIPTION
This addresses #7 

Due to the test run under Linux and fail under MacOSX we need to merge it to the newly created branch `feature/new-test-script`

<!---
@huboard:{"order":8.0,"milestone_order":8.0,"custom_state":""}
-->
